### PR TITLE
standaardenregister.json: trigger rebuild Bodem en Ondergrond

### DIFF
--- a/standaardenregister.json
+++ b/standaardenregister.json
@@ -151,7 +151,7 @@
   {
     "repository": "https://github.com/Informatievlaanderen/OSLOthema-bodemEnOndergrond",
     "configuration": "bodemenondergrond-AP-Bodem-config.json",
-    "rebuild": 4
+    "rebuild": 5
   },
   {
     "repository": "https://github.com/Informatievlaanderen/OSLOthema-bodemEnOndergrond",


### PR DESCRIPTION
Bodem en Ondergrond is nu herkend als Erkende Standaard door het Stuurorgaan, trigger een rebuild zodat deze aanpassingen gepubliceerd worden.

Vereist https://github.com/Informatievlaanderen/OSLOthema-bodemEnOndergrond/pull/122