### PR TITLE
standaardenregister.json: trigger rebuild Energiehuis

### DIFF
--- a/standaardenregister.json
+++ b/standaardenregister.json
@@ -26,12 +26,12 @@
   {
     "repository": "https://github.com/Informatievlaanderen/OSLOthema-energiehuis",
     "configuration": "ap-config.json",
-    "rebuild": 8
+    "rebuild": 9
   },
   {
     "repository": "https://github.com/Informatievlaanderen/OSLOthema-energiehuis",
     "configuration": "voc-config.json",
-    "rebuild": 8
+    "rebuild": 9
   },
   {
     "repository": "https://github.com/Informatievlaanderen/OSLOthema-hulpEnDienstverleningAanGedetineerden",


### PR DESCRIPTION
Energiehuis metadata op het OSLO Standaardenregister is niet up-to-date, retrigger build.